### PR TITLE
Fix nullability warnings

### DIFF
--- a/Solutions/Z3.LinqBinding/Environment.cs
+++ b/Solutions/Z3.LinqBinding/Environment.cs
@@ -8,7 +8,7 @@
     {
         public Expr? Expr { get; set; }
 
-        public Dictionary<MemberInfo, Environment> Properties { get; set; } = new Dictionary<MemberInfo, Environment>();
+        public Dictionary<MemberInfo, Environment> Properties { get; private set; } = new Dictionary<MemberInfo, Environment>();
 
         public Boolean IsArray { get; set; }
     }


### PR DESCRIPTION
Mostly this involved tweaking the code to better express actual expectations around nullability. And in a couple of places, I added a `!` because we're dealing with APIs that don't fit well with nullable reference types.